### PR TITLE
feat: publicConfig on Spa for runtime-fetched config

### DIFF
--- a/platform/spa/composition.yaml
+++ b/platform/spa/composition.yaml
@@ -21,6 +21,7 @@ spec:
             {{- $params := .observed.composite.resource.spec.parameters }}
             {{- $namespace := $params.namespace }}
             {{- $apiProxies := $params.apiProxies | default list }}
+            {{- $publicConfig := $params.publicConfig | default dict }}
             {{- $sizeResourceMap := dict "xs" (dict "cpuReq" "25m" "cpuLim" "100m" "memReq" "32Mi" "memLim" "64Mi") "sm" (dict "cpuReq" "50m" "cpuLim" "200m" "memReq" "64Mi" "memLim" "128Mi") "md" (dict "cpuReq" "100m" "cpuLim" "500m" "memReq" "128Mi" "memLim" "256Mi") "lg" (dict "cpuReq" "250m" "cpuLim" "1000m" "memReq" "256Mi" "memLim" "512Mi") }}
             {{- $sizeKey := $params.size | default "sm" }}
             {{- $sizeRes := get $sizeResourceMap $sizeKey | default (get $sizeResourceMap "sm") }}
@@ -102,6 +103,21 @@ spec:
                         add_header Content-Type text/plain always;
                         add_header Access-Control-Allow-Origin '*' always;
                     }
+
+                    {{- if gt (len $publicConfig) 0 }}
+                    # Fetched by the app on load — never baked into the JS bundle at build
+                    # time, so one image stays deployable unchanged across environments.
+                    # Mounted whole (not subPath), so kubelet syncs edits without a restart.
+                    location = /config.json {
+                        alias /etc/spa-public-config/config.json;
+                        # .json isn't in nginx's default mime.types, so without this it would
+                        # serve as application/octet-stream. add_header can't fix a Content-Type
+                        # nginx computes internally — default_type is the directive that does.
+                        default_type application/json;
+                        add_header Cache-Control "no-cache" always;
+                        add_header X-Content-Type-Options "nosniff" always;
+                    }
+                    {{- end }}
 
                     # no-cache: browser always refetches the entry point
                     # All security headers repeated — nginx drops server-level add_header
@@ -317,6 +333,22 @@ spec:
                         try_files $uri $uri/ /index.html;
                     }
                 }
+            {{- if gt (len $publicConfig) 0 }}
+            ---
+            # --- Public config ConfigMap ---
+            # Served as /config.json. Public by design — never put a secret in publicConfig.
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: {{ $name }}-public-config
+              namespace: {{ $namespace }}
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: public-config
+                gotemplating.fn.crossplane.io/ready: "True"
+            data:
+              config.json: |
+                {{ $publicConfig | toJson }}
+            {{- end }}
             ---
             # --- ServiceAccount ---
             # Dedicated SA per Spa instance — pods do not use the namespace default SA.
@@ -395,6 +427,11 @@ spec:
                           mountPath: /etc/nginx/conf.d/default.conf
                           subPath: default.conf
                           readOnly: true
+                        {{- if gt (len $publicConfig) 0 }}
+                        - name: public-config
+                          mountPath: /etc/spa-public-config
+                          readOnly: true
+                        {{- end }}
                         - name: run
                           mountPath: /run
                         - name: nginx-cache
@@ -405,6 +442,13 @@ spec:
                     - name: nginx-config
                       configMap:
                         name: {{ $name }}-nginx-config
+                    {{- if gt (len $publicConfig) 0 }}
+                    # Whole-directory mount, not subPath — kubelet syncs ConfigMap edits into
+                    # this one on its own, so publicConfig changes reach the pod with no restart.
+                    - name: public-config
+                      configMap:
+                        name: {{ $name }}-public-config
+                    {{- end }}
                     # nginx writes its pid to /run and its proxy/client temp files to
                     # /var/cache/nginx — both on a read-only root without these.
                     - name: run

--- a/platform/spa/xrd.yaml
+++ b/platform/spa/xrd.yaml
@@ -64,6 +64,17 @@ spec:
                     namespace:
                       type: string
                       description: "Namespace to deploy into. Must already exist (created by the tenant's namespace.yaml)."
+                    publicConfig:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      description: >-
+                        Flat key/value pairs served as JSON at /config.json, fetched by the
+                        app on load instead of being baked into the JS bundle at build time —
+                        this keeps one built image deployable across environments unchanged.
+                        Everything here is shipped to any browser that asks: a public API
+                        base URL, a public analytics key, a feature flag. Never a secret —
+                        there is no boundary protecting this file from anyone.
                     apiProxies:
                       type: array
                       description: "Use when this SPA has companion Apis. Each entry routes one path prefix to one in-cluster service; the prefix is stripped before proxying. The Apis need no hostname or Cloudflare Tunnel entry of their own — only the SPA is exposed, and how far depends on its tlsIssuer."


### PR DESCRIPTION
## Problem

`Spa` builds commonly bake config into the JS at build time: bundlers (Vite, webpack,
CRA) substitute env vars from the CI runner directly into the compiled output. Nothing
stops a client-rendered app from fetching its config at runtime instead, a browser can
make an HTTP request the same way it calls any other API, but that's not what tooling
defaults to. Once baked in, the artifact stops being portable: a bundle built for
staging can't move to prod unchanged, and every value change means shipping a new
image.

## Solution

Add `publicConfig` to the `Spa` XRD: the app fetches values (an API URL, a feature
flag, a public analytics key) live from `/config.json` at load time instead of baking
them in. Rendered as a ConfigMap mounted as a whole directory (not subPath), so kubelet
delivers edits with no pod restart. Opt-in, existing `Spa` instances render unchanged.

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 60}}}%%
flowchart LR
    browser["Browser\nstatic JS bundle,\nvalues never baked in"]
    spa["Spa pod\nnginx"]
    cm["ConfigMap\npublicConfig from the XR"]

    browser -->|"GET /config.json"| spa
    cm -->|"mounted whole"| spa
    spa -->|"current values"| browser
```

## Nothing Novel

Defer config to container start, not build time, so one image works everywhere, this
is Twelve-Factor App's Config principle, and nginx's own maintainers ship a mechanism
for it by default in the base image this composition builds on.

Reference: [nginx official Docker image - envsubst on templates](https://github.com/nginx/docker-nginx/blob/master/entrypoint/20-envsubst-on-templates.sh)
